### PR TITLE
Update Ruff target-version to py312

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ extend-exclude = [
     "third_party",
 ]
 src = ["sharp"]
-target-version = "py39"
+target-version = "py313"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ extend-exclude = [
     "third_party",
 ]
 src = ["sharp"]
-target-version = "py313"
+target-version = "py312"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/sharp/cli/render.py
+++ b/src/sharp/cli/render.py
@@ -87,8 +87,8 @@ def render_gaussians(
 
     intrinsics = torch.tensor(
         [
-            [f_px, 0, (width - 1) / 2., 0],
-            [0, f_px, (height - 1) / 2., 0],
+            [f_px, 0, (width - 1) / 2.0, 0],
+            [0, f_px, (height - 1) / 2.0, 0],
             [0, 0, 1, 0],
             [0, 0, 0, 1],
         ],


### PR DESCRIPTION
### What changed

* Updated Ruff `target-version` from `py39` to `py312`.

### Why

* The project runs on Python 3.13, while Ruff currently supports target versions up to Python 3.12.
* Using `py312` aligns linting semantics more closely with the runtime and avoids evaluating the codebase against outdated Python 3.9 rules.

### Context

* Follow-up to Issue #9.

### Notes

* Ruff does not yet support `py313`; `py312` is the closest supported target.
* No runtime or model behavior changes.