### PR TITLE
Fix inference crash and dark rendering output

### DIFF
--- a/src/sharp/utils/gaussians.py
+++ b/src/sharp/utils/gaussians.py
@@ -329,7 +329,6 @@ def load_ply(path: Path) -> tuple[Gaussians3D, SceneMetaData]:
     quaternions = torch.from_numpy(quaternions).view(1, -1, 4).float()
     singular_values = torch.exp(torch.from_numpy(scale_logits).view(1, -1, 3)).float()
     opacities = torch.sigmoid(torch.from_numpy(opacity_logits).view(1, -1)).float()
-    # colors = torch.from_numpy(colors).view(1, -1, 3).float()
 
     gaussians = Gaussians3D(
         mean_vectors=mean_vectors,

--- a/src/sharp/utils/gaussians.py
+++ b/src/sharp/utils/gaussians.py
@@ -320,6 +320,8 @@ def load_ply(path: Path) -> tuple[Gaussians3D, SceneMetaData]:
     # Parse color space.
     color_space_index = supplement_data.get("color_space", 1)
     color_space = cs_utils.decode_color_space(color_space_index)
+    colors = torch.from_numpy(colors).view(1, -1, 3).float()
+
     if color_space == "sRGB":
         colors = cs_utils.sRGB2linearRGB(colors)
 
@@ -327,7 +329,7 @@ def load_ply(path: Path) -> tuple[Gaussians3D, SceneMetaData]:
     quaternions = torch.from_numpy(quaternions).view(1, -1, 4).float()
     singular_values = torch.exp(torch.from_numpy(scale_logits).view(1, -1, 3)).float()
     opacities = torch.sigmoid(torch.from_numpy(opacity_logits).view(1, -1)).float()
-    colors = torch.from_numpy(colors).view(1, -1, 3).float()
+    # colors = torch.from_numpy(colors).view(1, -1, 3).float()
 
     gaussians = Gaussians3D(
         mean_vectors=mean_vectors,

--- a/src/sharp/utils/gsplat.py
+++ b/src/sharp/utils/gsplat.py
@@ -118,7 +118,7 @@ class GSplatRenderer(nn.Module):
 
             # Colorspace conversion.
             if self.color_space == "sRGB":
-                pass
+                rendered_color = cs_utils.linearRGB2sRGB(rendered_color)
             elif self.color_space == "linearRGB":
                 rendered_color = cs_utils.linearRGB2sRGB(rendered_color)
             else:


### PR DESCRIPTION
- Fixed TypeError in load_ply by converting numpy array to tensor before calling sRGB2linearRGB
- Fixed dark rendering issue by ensuring sRGB conversion is applied when input/output is sRGB (even if internal state is linear)

My testing file uses sRGB
I attach it here so you can reproduce the problem
![loki1](https://github.com/user-attachments/assets/45742b94-1851-46ed-b75b-233cf2b14fed)


Error message for the original code:


```
>>>sharp render -i output -o renderings


2025-12-18 13:38:15,124 | INFO | Rendering output/loki.ply
Traceback (most recent call last):
  File "/scratch3/metzgern/random/ml-sharp/.venv/bin/sharp", line 8, in <module>
    sys.exit(main_cli())
             ^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/.venv/lib/python3.11/site-packages/click/core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/.venv/lib/python3.11/site-packages/click/core.py", line 1383, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/.venv/lib/python3.11/site-packages/click/core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/.venv/lib/python3.11/site-packages/click/core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/.venv/lib/python3.11/site-packages/click/core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/src/sharp/cli/render.py", line 61, in render_cli
    gaussians, metadata = load_ply(scene_path)
                          ^^^^^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/src/sharp/utils/gaussians.py", line 326, in load_ply
    colors = cs_utils.sRGB2linearRGB(colors)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/src/sharp/utils/color_space.py", line 52, in sRGB2linearRGB
    return robust_where(
           ^^^^^^^^^^^^^
  File "/scratch3/metzgern/random/ml-sharp/src/sharp/utils/robust.py", line 40, in robust_where
    input_2 = torch.where(~condition, input_2, branch_false_safe_value)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: where() received an invalid combination of arguments - got (numpy.ndarray, numpy.ndarray, float), but expected one of:
 * (Tensor condition)
 * (Tensor condition, Tensor input, Tensor other, *, Tensor out = None)
 * (Tensor condition, Number self, Tensor other)
      didn't match because some of the arguments have invalid types: (numpy.ndarray, numpy.ndarray, float)
 * (Tensor condition, Tensor input, Number other)
      didn't match because some of the arguments have invalid types: (numpy.ndarray, numpy.ndarray, float)
 * (Tensor condition, Number self, Number other)
      didn't match because some of the arguments have invalid types: (numpy.ndarray, numpy.ndarray, float)
```