### PR TITLE
Fix crash by replacing deprecated logger.warn with logger.warning

### DIFF
--- a/src/sharp/utils/io.py
+++ b/src/sharp/utils/io.py
@@ -58,7 +58,7 @@ def load_rgb(
     if f_35mm is None or f_35mm < 1:
         f_35mm = img_exif.get("FocalLength", None)
         if f_35mm is None:
-            LOGGER.warn(f"Did not find focallength in exif data of {path} - Setting to 30mm.")
+            LOGGER.warning(f"Did not find focallength in exif data of {path} - Setting to 30mm.")
             f_35mm = 30.0
         if f_35mm < 10.0:
             LOGGER.info("Found focal length below 10mm, assuming it's not for 35mm.")


### PR DESCRIPTION
## Description
This pull request fixes an `AttributeError: 'Logger' object has no attribute 'warn'` that occurs during inference.

In Python 3.13, the `warn()` method has been removed, leading to a crash. Replacing it with `warning()`, the standard recommended method, resolves this issue and ensures the tool remains usable in modern environments.

## Changes
- Updated `src/sharp/utils/io.py`: Changed `LOGGER.warn()` to `LOGGER.warning()`.
- Verified using `grep -r --include="*.py" "\.warn(" .` that no other occurrences of `.warn()` exist within the `src` directory.

## Impact
This is a non-breaking change that prevents the application from crashing when EXIF data (focal length) is missing from input images.

## Testing
- Verified the fix by running the prediction CLI. The error no longer occurs, and the fallback message is correctly logged using `.warning()`.

---
*By submitting this pull request, I represent that I have the right to license my contribution to Apple and the community, and agree that my contributions are licensed under the LICENSE of this repository.*