### PR TITLE
Fix CLI help text for render command

### DIFF
--- a/src/sharp/cli/render.py
+++ b/src/sharp/cli/render.py
@@ -37,7 +37,7 @@ LOGGER = logging.getLogger(__name__)
 )
 @click.option("-v", "--verbose", is_flag=True, help="Activate debug logs.")
 def render_cli(input_path: Path, output_path: Path, verbose: bool):
-    """Predict Gaussians from input images."""
+    """Render videos from predicted Gaussians with a camera trajectory (CUDA only)."""
     logging_utils.configure(logging.DEBUG if verbose else logging.INFO)
 
     if not torch.cuda.is_available():


### PR DESCRIPTION
- Problem: sharp render --help shows the same description as predict (“Predict Gaussians from input images.”), which is misleading.
- Fix: Update the render command docstring so the CLI help correctly states that it renders videos from predicted Gaussians with a camera trajectory (CUDA only).
- Behavior: No functional change; help text only.
- Validation: sharp render --help now displays the corrected description.

```bash
❯ sharp render --help
Usage: sharp render [OPTIONS]

Render videos from predicted Gaussians with a camera trajectory (CUDA only).

Options:
-i, --input-path PATH        Path to the ply or a list of plys.  [required]
-o, --output-path DIRECTORY  Path to save the rendered videos.  [required]
-v, --verbose                Activate debug logs.
--help                       Show this message and exit.
```