### PR TITLE
feat: initial enablement for XPU device

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Afterwards, you can install the project using
 pip install -r requirements.txt
 ```
 
+If you are using *Intel GPU*, you can install the project using the command below
+
+```
+pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/xpu
+```
+
 To test the installation, run
 
 ```

--- a/src/sharp/cli/predict.py
+++ b/src/sharp/cli/predict.py
@@ -70,7 +70,7 @@ DEFAULT_MODEL_URL = "https://ml-site.cdn-apple.com/models/sharp/sharp_2572gikvuh
     "--device",
     type=str,
     default="default",
-    help="Device to run on. ['cpu', 'mps', 'cuda']",
+    help="Device to run on. ['cpu', 'mps', 'cuda', 'xpu']",
 )
 @click.option("-v", "--verbose", is_flag=True, help="Activate debug logs.")
 def predict_cli(
@@ -103,6 +103,8 @@ def predict_cli(
     if device == "default":
         if torch.cuda.is_available():
             device = "cuda"
+        elif torch.xpu.is_available():
+            device = "xpu"
         elif torch.mps.is_available():
             device = "mps"
         else:


### PR DESCRIPTION
This pull request adds support for running the project on Intel GPUs using the `xpu` device with PyTorch. The changes update documentation and code to recognize and utilize Intel GPU hardware, making the installation and prediction process more flexible.

Intel GPU support:

* Updated `README.md` to include installation instructions for Intel GPU users, specifying the use of the `--extra-index-url` flag to access PyTorch's XPU wheels.
* Extended the `--device` option help text in `src/sharp/cli/predict.py` to mention `xpu` as a supported device.
* Modified device selection logic in `predict_cli` to check for Intel GPU availability using `torch.xpu.is_available()` and set the device to `xpu` if available.