### PR TITLE
fix(VideoWriter): close depth_writer in close() method

### DIFF
--- a/src/sharp/utils/io.py
+++ b/src/sharp/utils/io.py
@@ -189,6 +189,7 @@ class VideoWriter(OutputWriter):
         self.image_writer = iio.get_writer(output_path, fps=fps)
 
         self.max_depth_estimate = None
+        self.depth_writer = None
         if render_depth:
             self.depth_writer = iio.get_writer(output_path.with_suffix(".depth.mp4"), fps=fps)
 
@@ -211,3 +212,5 @@ class VideoWriter(OutputWriter):
     def close(self):
         """Finish writing."""
         self.image_writer.close()
+        if self.depth_writer is not None:
+            self.depth_writer.close()


### PR DESCRIPTION
## Summary

The `VideoWriter` class was not closing the depth video writer in its `close()` method, causing depth map video files (`.depth.mp4`) to be corrupted/unplayable.

## Problem

When using `VideoWriter` with `render_depth=True`, the depth video files are never finalized because `close()` only closes `image_writer`:

```python
def close(self):
    """Finish writing."""
    self.image_writer.close()
    # depth_writer is never closed!
```

The `imageio` writer requires `close()` to be called to write the video file headers and finalize the container.

## Fix

1. Initialize `self.depth_writer = None` before the conditional assignment (also fixes a potential `AttributeError` if `render_depth=False` and code elsewhere checks `self.depth_writer`)
2. Close `depth_writer` in the `close()` method if it exists

## Testing

Verified that depth map videos are now playable after this fix.